### PR TITLE
check if message type implements `ax.Message` in `TypeByName` function

### DIFF
--- a/src/ax/type.go
+++ b/src/ax/type.go
@@ -30,15 +30,22 @@ func TypeOf(m Message) MessageType {
 // TypeByName returns the message type for a fully-qualified Protocol Buffers
 // message name.
 //
-// If the message type is registered, mt is the message type of n, and ok is
-// true; otherwise, ok is false.
+// If the message type is registered and mt is the message type of `ax.Message`,
+// ok is true; otherwise, ok is false.
 //
 // Note that messages are only added to the registry when their respective Go
 // package is imported.
 func TypeByName(n string) (mt MessageType, ok bool) {
+
 	rt := proto.MessageType(n)
 
 	if rt == nil {
+		return MessageType{}, false
+	}
+
+	axMessageType := reflect.TypeOf((*Message)(nil)).Elem()
+
+	if !rt.Implements(axMessageType) {
 		return MessageType{}, false
 	}
 

--- a/src/ax/type.go
+++ b/src/ax/type.go
@@ -30,8 +30,8 @@ func TypeOf(m Message) MessageType {
 // TypeByName returns the message type for a fully-qualified Protocol Buffers
 // message name.
 //
-// If the message type is registered and mt is the message type of `ax.Message`,
-// ok is true; otherwise, ok is false.
+// If n is the name of a registered implementation of Message,
+// then mt is the type of that message, and ok is true; otherwise, ok is false.
 //
 // Note that messages are only added to the registry when their respective Go
 // package is imported.

--- a/src/ax/type_test.go
+++ b/src/ax/type_test.go
@@ -23,6 +23,7 @@ var _ = Describe("MessageType", func() {
 	})
 
 	Describe("TypeByName", func() {
+
 		It("returns a message type with the correct name", func() {
 			mt, ok := TypeByName("ax.internal.messagetest.Message")
 			Expect(ok).To(BeTrue())
@@ -37,6 +38,11 @@ var _ = Describe("MessageType", func() {
 
 		It("returns false if the message name is not registered", func() {
 			_, ok := TypeByName("ax.internal.messagetest.Unknown")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns false if the message name is registered, but the message type is not of ax.Message", func() {
+			_, ok := TypeByName("ax.internal.messagetest.NonAxMessage")
 			Expect(ok).To(BeFalse())
 		})
 	})


### PR DESCRIPTION
fixes #3