### PR TITLE
Refactor 'evented data' so that it is the saga that is evented, rather than the data.

### DIFF
--- a/examples/banking/account/account.go
+++ b/examples/banking/account/account.go
@@ -20,20 +20,6 @@ func (a *Account) InstanceDescription() string {
 	)
 }
 
-// ApplyEvent updates the data to reflect the fact that ev has occurred.
-func (a *Account) ApplyEvent(env ax.Envelope) {
-	switch ev := env.Message.(type) {
-	case *messages.AccountOpened:
-		a.AccountId = ev.AccountId
-		a.Name = ev.Name
-		a.IsOpen = true
-	case *messages.AccountCredited:
-		a.Balance += ev.Cents
-	case *messages.AccountDebited:
-		a.Balance -= ev.Cents
-	}
-}
-
 // AggregateRoot is a saga that implements the Account aggregate.
 var AggregateRoot saga.Saga = &aggregateRoot{}
 
@@ -113,4 +99,20 @@ func (aggregateRoot) HandleMessage(
 	}
 
 	return
+}
+
+// ApplyEvent updates the data to reflect the fact that ev has occurred.
+func (aggregateRoot) ApplyEvent(d saga.Data, env ax.Envelope) {
+	acct := d.(*Account)
+
+	switch ev := env.Message.(type) {
+	case *messages.AccountOpened:
+		acct.AccountId = ev.AccountId
+		acct.Name = ev.Name
+		acct.IsOpen = true
+	case *messages.AccountCredited:
+		acct.Balance += ev.Cents
+	case *messages.AccountDebited:
+		acct.Balance -= ev.Cents
+	}
 }

--- a/src/ax/saga/applier.go
+++ b/src/ax/saga/applier.go
@@ -7,9 +7,11 @@ import (
 )
 
 // Applier is an implementation of ax.Sender that applies published
-// events to an EventedData instance.
+// events to saga data for evented sagas.
 type Applier struct {
-	Data EventedData
+	Saga EventedSaga
+	Data Data
+
 	Next ax.Sender
 }
 
@@ -31,7 +33,7 @@ func (s *Applier) PublishEvent(ctx context.Context, m ax.Event) (ax.Envelope, er
 		return ax.Envelope{}, err
 	}
 
-	s.Data.ApplyEvent(env)
+	s.Saga.ApplyEvent(s.Data, env)
 
 	return env, nil
 }

--- a/src/ax/saga/data.go
+++ b/src/ax/saga/data.go
@@ -2,7 +2,6 @@ package saga
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/jmalloc/ax/src/ax"
 )
 
 // Data is an interface for application-defined data associated with a saga
@@ -19,16 +18,4 @@ type Data interface {
 	// Follow the same conventions as for error messages:
 	// https://github.com/golang/go/wiki/CodeReviewComments#error-strings
 	InstanceDescription() string
-}
-
-// EventedData is a specialization of Data for sagas that use events to update
-// their state. Event-sourced sagas always use EventedData.
-type EventedData interface {
-	Data
-
-	// ApplyEvent updates the data to reflect the fact that an event has
-	// occurred.
-	//
-	// It may panic if env.Message does not implement ax.Event.
-	ApplyEvent(env ax.Envelope)
 }

--- a/src/ax/saga/eventsourcing/messagestore.go
+++ b/src/ax/saga/eventsourcing/messagestore.go
@@ -45,6 +45,7 @@ func applyEvents(
 	ctx context.Context,
 	tx persistence.Tx,
 	ms persistence.MessageStore,
+	sg saga.EventedSaga,
 	i *saga.Instance,
 ) error {
 	s, err := ms.OpenStream(
@@ -56,8 +57,6 @@ func applyEvents(
 	if err != nil {
 		return err
 	}
-
-	data := i.Data.(saga.EventedData)
 
 	for {
 		ok, err := s.Next(ctx)
@@ -78,7 +77,7 @@ func applyEvents(
 			)
 		}
 
-		data.ApplyEvent(env)
+		sg.ApplyEvent(i.Data, env)
 		i.Revision++
 	}
 }

--- a/src/ax/saga/eventsourcing/persister.go
+++ b/src/ax/saga/eventsourcing/persister.go
@@ -62,7 +62,13 @@ func (p *Persister) BeginUpdate(
 		}
 	}
 
-	if err := applyEvents(ctx, tx, p.MessageStore, &i); err != nil {
+	if err := applyEvents(
+		ctx,
+		tx,
+		p.MessageStore,
+		sg.(saga.EventedSaga),
+		&i,
+	); err != nil {
 		return nil, err
 	}
 

--- a/src/ax/saga/handler.go
+++ b/src/ax/saga/handler.go
@@ -155,8 +155,8 @@ func (h *MessageHandler) handleMessage(
 		panic("unit-of-work contains saga instance with nil data")
 	}
 
-	if d, ok := i.Data.(EventedData); ok {
-		s = &Applier{d, s}
+	if es, ok := h.Saga.(EventedSaga); ok {
+		s = &Applier{es, i.Data, s}
 	}
 
 	if err := h.Saga.HandleMessage(ctx, s, env, i); err != nil {

--- a/src/ax/saga/saga.go
+++ b/src/ax/saga/saga.go
@@ -85,3 +85,15 @@ type Saga interface {
 	// that could not be found.
 	HandleNotFound(context.Context, ax.Sender, ax.Envelope) error
 }
+
+// EventedSaga is a saga that only mutates its data when an event occurs.
+// CRUD sagas may be evented or non-evented, but eventsourced sagas are always
+// evented.
+type EventedSaga interface {
+	Saga
+
+	// ApplyEvent updates d to reflect the fact that an event has occurred.
+	//
+	// It may panic if env.Message does not implement ax.Event.
+	ApplyEvent(d Data, env ax.Envelope)
+}

--- a/src/ax/saga/saga.go
+++ b/src/ax/saga/saga.go
@@ -87,8 +87,12 @@ type Saga interface {
 }
 
 // EventedSaga is a saga that only mutates its data when an event occurs.
+//
 // CRUD sagas may be evented or non-evented, but eventsourced sagas are always
 // evented.
+//
+// Implementors should take care not to mutate the saga data directly inside the
+// saga HandleMessage() method, only in ApplyEvent().
 type EventedSaga interface {
 	Saga
 


### PR DESCRIPTION
This is in preparation for #10, which requires separation of the event handling and the data instance.