### PR TITLE
Allow `Saga.MappingKeyForMessage()` to indicate that the message should be ignored.

### DIFF
--- a/examples/banking/account/account.go
+++ b/examples/banking/account/account.go
@@ -49,12 +49,12 @@ func (aggregateRoot) NewData() saga.Data {
 	return &Account{}
 }
 
-func (aggregateRoot) MappingKeyForMessage(ctx context.Context, env ax.Envelope) (string, error) {
+func (aggregateRoot) MappingKeyForMessage(ctx context.Context, env ax.Envelope) (string, bool, error) {
 	type hasAccountID interface {
 		GetAccountId() string
 	}
 
-	return env.Message.(hasAccountID).GetAccountId(), nil
+	return env.Message.(hasAccountID).GetAccountId(), true, nil
 }
 
 func (aggregateRoot) MappingKeysForInstance(

--- a/src/ax/saga/saga.go
+++ b/src/ax/saga/saga.go
@@ -51,14 +51,15 @@ type Saga interface {
 	NewData() Data
 
 	// MappingKeyForMessage returns the key used to locate the saga instance
-	// to which the given message is routed.
+	// to which the given message is routed, if any.
 	//
-	// The message is routed to the saga instance that contains k in its
-	// associated key set.
+	// If ok is false the message is ignored; otherwise, the message is routed
+	// to the saga instance that contains k in its associated key set.
 	//
-	// If no saga instance is found and the message is a "trigger" message, a
-	// new instance is created; otherwise, HandleNotFound() is called.
-	MappingKeyForMessage(ctx context.Context, env ax.Envelope) (k string, err error)
+	// New saga instances are created when no matching instance can be found
+	// and the message is declared as a "trigger" by the saga's MessageTypes()
+	// method; otherwise, HandleNotFound() is called.
+	MappingKeyForMessage(ctx context.Context, env ax.Envelope) (k string, ok bool, err error)
 
 	// MappingKeysForInstance returns the set of mapping keys associated with
 	// the given instance.


### PR DESCRIPTION
Fixes #65