### PR TITLE
Fix faulty "new saga instance" behaviour as a result of the mapping refactor.

### DIFF
--- a/src/ax/persistence/messagestore.go
+++ b/src/ax/persistence/messagestore.go
@@ -22,14 +22,14 @@ type MessageStore interface {
 
 	// OpenStream opens a stream of messages for reading from a specific offset.
 	//
-	// The offset may be past the end of the stream. It returns an error if
-	// the stream does not exist.
+	// The offset may be past the end of the stream. It returns false if the
+	// stream does not exist.
 	OpenStream(
 		ctx context.Context,
 		tx Tx,
 		stream string,
 		offset uint64,
-	) (MessageStream, error)
+	) (MessageStream, bool, error)
 }
 
 // MessageStream is a stream of messages stored in a MessageStore.

--- a/src/ax/saga/handler.go
+++ b/src/ax/saga/handler.go
@@ -38,117 +38,77 @@ func (h *MessageHandler) HandleMessage(ctx context.Context, s ax.Sender, env ax.
 	defer com.Rollback()
 	ctx = persistence.WithTx(ctx, tx)
 
-	res, id, err := h.Mapper.MapMessageToInstance(ctx, h.Saga, tx, env)
-	if err != nil {
+	// begin a new unit of work.
+	// if ok is false the message is not map to any instance and is ignored.
+	w, ok, err := h.begin(ctx, tx, s, env)
+	if !ok || err != nil {
+		return err
+	}
+	defer w.Close()
+
+	// call the not-found handler if the instance is new but the message is not a
+	// trigger.
+	if w.Instance().Revision == 0 && !h.isTrigger(env) {
+		return h.Saga.HandleNotFound(ctx, s, env)
+	}
+
+	// otherwise, forward the message to the saga for handling.
+	if err := h.forward(ctx, w, env); err != nil {
 		return err
 	}
 
-	switch res {
-	case MapResultFound:
-		err = h.handleUpdate(ctx, tx, s, env, id)
-	case MapResultNotFound:
-		err = h.handleCreate(ctx, tx, s, env)
-	case MapResultIgnore:
-		return nil
-	default:
-		panic("unexpected map result type")
-	}
-
-	if err != nil {
+	// then persist the changes.
+	if err := h.save(ctx, tx, w); err != nil {
 		return err
 	}
 
 	return com.Commit()
 }
 
-// handleCreate handles a message that applies to a new saga instance.
-// It calls the not-found handler if the message is not a "trigger" message.
-func (h *MessageHandler) handleCreate(
+// begin starts a new unit-of-work.
+//
+// It returns false if the message is not mapped to any instance and hence
+// should be ignored.
+func (h *MessageHandler) begin(
 	ctx context.Context,
 	tx persistence.Tx,
 	s ax.Sender,
 	env ax.Envelope,
-) error {
-	triggers, _ := h.Saga.MessageTypes()
-	if !triggers.Has(env.Type()) {
-		return h.Saga.HandleNotFound(ctx, s, env)
+) (UnitOfWork, bool, error) {
+	id, ok, err := h.Mapper.MapMessageToInstance(ctx, h.Saga, tx, env)
+	if !ok || err != nil {
+		return nil, false, err
 	}
 
-	i, err := h.newInstance(ctx, env)
-	if err != nil {
-		return err
-	}
-
-	w, err := h.Persister.BeginCreate(ctx, h.Saga, tx, s, i)
-	if err != nil {
-		return err
-	}
-
-	return h.handleMessage(ctx, tx, w, env)
+	w, err := h.Persister.BeginUnitOfWork(ctx, h.Saga, tx, s, id)
+	return w, true, err
 }
 
-// handleUpdate handles a message that applies to an existing saga instance.
-func (h *MessageHandler) handleUpdate(
-	ctx context.Context,
-	tx persistence.Tx,
-	s ax.Sender,
-	env ax.Envelope,
-	id InstanceID,
-) error {
-	w, err := h.Persister.BeginUpdate(ctx, h.Saga, tx, s, id)
-	if err != nil {
-		return err
-	}
-
-	return h.handleMessage(ctx, tx, w, env)
-}
-
-// newInstance returns a new saga instance.
-func (h *MessageHandler) newInstance(ctx context.Context, env ax.Envelope) (Instance, error) {
-	id, err := h.Saga.GenerateInstanceID(ctx, env)
-	if err != nil {
-		return Instance{}, err
-	}
-
-	return Instance{
-		InstanceID: id,
-		Data:       h.Saga.NewData(),
-	}, nil
-}
-
-// handleMessage passes the message to the saga for handling, then persists
-// any changes to the instance.
-func (h *MessageHandler) handleMessage(
-	ctx context.Context,
-	tx persistence.Tx,
-	w UnitOfWork,
-	env ax.Envelope,
-) error {
+// forward passes the message to the saga to be handled.
+func (h *MessageHandler) forward(ctx context.Context, w UnitOfWork, env ax.Envelope) error {
 	i := w.Instance()
 	s := w.Sender()
-
-	if i.Data == nil {
-		panic("unit-of-work contains saga instance with nil data")
-	}
 
 	if es, ok := h.Saga.(EventedSaga); ok {
 		s = &Applier{es, i.Data, s}
 	}
 
-	if err := h.Saga.HandleMessage(ctx, s, env, i); err != nil {
-		return err
-	}
+	return h.Saga.HandleMessage(ctx, s, env, i)
+}
 
+// save persists changes to the saga instance.
+func (h *MessageHandler) save(ctx context.Context, tx persistence.Tx, w UnitOfWork) error {
 	ok, err := w.Save(ctx)
-	if err != nil {
+	if !ok || err != nil {
 		return err
 	}
 
-	if ok {
-		if err := h.Mapper.UpdateMapping(ctx, h.Saga, tx, i); err != nil {
-			return err
-		}
-	}
+	return h.Mapper.UpdateMapping(ctx, h.Saga, tx, w.Instance())
+}
 
-	return nil
+// isTrigger returns true if env contains a message type that can trigger a new
+// saga instance.
+func (h *MessageHandler) isTrigger(env ax.Envelope) bool {
+	triggers, _ := h.Saga.MessageTypes()
+	return triggers.Has(env.Type())
 }

--- a/src/ax/saga/mapper.go
+++ b/src/ax/saga/mapper.go
@@ -7,34 +7,19 @@ import (
 	"github.com/jmalloc/ax/src/ax/persistence"
 )
 
-// MapResult contains the result of a call to Mapper.MapMessageToInstance()
-type MapResult int
-
-const (
-	// MapResultFound indicates that an instance ID was found for the supplied
-	// message.
-	MapResultFound MapResult = iota
-
-	// MapResultNotFound indicates that no existing instance ID was found for the
-	// supplied message, and that a new instance should be created if possible.
-	MapResultNotFound
-
-	// MapResultIgnore indicates that this message should not be routed to any
-	// instance.
-	MapResultIgnore
-)
-
 // Mapper is an interface for mapping inbound messages to their target saga
 // instance.
 type Mapper interface {
 	// MapMessageToInstance returns the ID of the saga instance that is the
 	// target of the given message.
+	//
+	// It returns false if the message should be ignored.
 	MapMessageToInstance(
 		ctx context.Context,
 		sg Saga,
 		tx persistence.Tx,
 		env ax.Envelope,
-	) (MapResult, InstanceID, error)
+	) (InstanceID, bool, error)
 
 	// UpdateMapping notifies the mapper that a message has been handled by
 	// an instance. Giving it the opportunity to update mapping data to reflect

--- a/src/ax/saga/mapping/direct/mapper.go
+++ b/src/ax/saga/mapping/direct/mapper.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Mapper is an implementation of saga.Mapper that maps messages to saga
-// by treating a particular field in the message as the instance ID.
+// instances by having the saga implement a method that returns the instance ID
+// directly.
 //
 // The saga must implement the direct.Saga interface to use direct mapping.
 type Mapper struct{}
@@ -17,19 +18,14 @@ type Mapper struct{}
 // MapMessageToInstance returns the ID of the saga instance that is the target
 // of the given message.
 //
-// If no existing saga instance is found, it returns false.
+// It returns false if the message should be ignored.
 func (m *Mapper) MapMessageToInstance(
 	ctx context.Context,
 	sg saga.Saga,
 	tx persistence.Tx,
 	env ax.Envelope,
-) (saga.MapResult, saga.InstanceID, error) {
-	id, ok, err := sg.(Saga).InstanceIDForMessage(ctx, env)
-	if !ok || err != nil {
-		return saga.MapResultIgnore, saga.InstanceID{}, err
-	}
-
-	return saga.MapResultFound, id, nil
+) (saga.InstanceID, bool, error) {
+	return sg.(Saga).InstanceIDForMessage(ctx, env)
 }
 
 // UpdateMapping notifies the mapper that a message has been handled by

--- a/src/ax/saga/mapping/direct/pkg.go
+++ b/src/ax/saga/mapping/direct/pkg.go
@@ -1,3 +1,4 @@
-// Package direct provides a saga mapping strategy that maps messages to
-// instances by using only information contained in the message itself.
+// Package direct provides a saga mapping strategy that maps messages to saga
+// instances by having the saga implement a method that returns the instance ID
+// directly.
 package direct

--- a/src/ax/saga/mapping/keyset/saga.go
+++ b/src/ax/saga/mapping/keyset/saga.go
@@ -11,6 +11,12 @@ import (
 type Saga interface {
 	saga.Saga
 
+	// GenerateInstanceID returns the saga ID to use for a new instance.
+	//
+	// It is called when a "trigger" message is received and there is no
+	// existing saga instance. env contains the "trigger" message.
+	GenerateInstanceID(ctx context.Context, env ax.Envelope) (id saga.InstanceID, err error)
+
 	// MappingKeyForMessage returns the key used to locate the saga instance
 	// to which the given message is routed, if any.
 	//

--- a/src/ax/saga/persistence/crud/repository.go
+++ b/src/ax/saga/persistence/crud/repository.go
@@ -11,12 +11,16 @@ import (
 type Repository interface {
 	// LoadSagaInstance fetches a saga instance by its ID.
 	//
-	// It returns an error if the instance does not exist, or a problem occurs
-	// with the underlying data store.
+	// It returns an false if the instance does not exist. It returns an error
+	// if a problem occurs with the underlying data store.
 	//
 	// It panics if the repository is not able to enlist in tx because it uses a
 	// different underlying storage system.
-	LoadSagaInstance(ctx context.Context, tx persistence.Tx, id saga.InstanceID) (saga.Instance, error)
+	LoadSagaInstance(
+		ctx context.Context,
+		tx persistence.Tx,
+		id saga.InstanceID,
+	) (saga.Instance, bool, error)
 
 	// SaveSagaInstance persists a saga instance.
 	//

--- a/src/ax/saga/persistence/eventsourcing/messagestore.go
+++ b/src/ax/saga/persistence/eventsourcing/messagestore.go
@@ -48,13 +48,13 @@ func applyEvents(
 	sg saga.EventedSaga,
 	i *saga.Instance,
 ) error {
-	s, err := ms.OpenStream(
+	s, ok, err := ms.OpenStream(
 		ctx,
 		tx,
 		streamName(i.InstanceID),
 		uint64(i.Revision),
 	)
-	if err != nil {
+	if !ok || err != nil {
 		return err
 	}
 

--- a/src/ax/saga/persister.go
+++ b/src/ax/saga/persister.go
@@ -10,18 +10,11 @@ import (
 // Persister is an interface for loading saga instances, and persisting the
 // changes that occur to them.
 type Persister interface {
-	// BeginCreate starts a new unit-of-work that persists a new saga instance.
-	BeginCreate(
-		ctx context.Context,
-		sg Saga,
-		tx persistence.Tx,
-		s ax.Sender,
-		i Instance,
-	) (UnitOfWork, error)
-
-	// BeginUpdate starts a new unit-of-work that updates an existing saga
-	// instance.
-	BeginUpdate(
+	// BeginUnitOfWork starts a new unit-of-work that modifies a saga instance.
+	//
+	// If the saga instance does not exist, it returns a UnitOfWork with an
+	// instance at revision zero.
+	BeginUnitOfWork(
 		ctx context.Context,
 		sg Saga,
 		tx persistence.Tx,
@@ -42,4 +35,8 @@ type UnitOfWork interface {
 	// Save persists changes to the instance.
 	// It returns true if any changes have occurred.
 	Save(ctx context.Context) (bool, error)
+
+	// Close is called when the unit-of-work has ended, regardless of whether
+	// Save() has been called.
+	Close()
 }

--- a/src/ax/saga/saga.go
+++ b/src/ax/saga/saga.go
@@ -38,12 +38,6 @@ type Saga interface {
 	// method is called instead.
 	MessageTypes() (tr ax.MessageTypeSet, mt ax.MessageTypeSet)
 
-	// GenerateInstanceID returns the saga ID to use for a new instance.
-	//
-	// It is called when a "trigger" message is received and there is no
-	// existing saga instance. env contains the "trigger" message.
-	GenerateInstanceID(ctx context.Context, env ax.Envelope) (id InstanceID, err error)
-
 	// NewData returns a pointer to a new zero-value instance of the
 	// saga's data type.
 	NewData() Data


### PR DESCRIPTION
The previous change had a design flaw insofar as the onus was put on the mapper to decide whether a message would be applied to a new saga instance or an existing instance.

This was possible for keyset based mapper, because it had database entries if and only the saga instance already exited, but is not possible for the direct mapper because it is stateless.

This change modifies the interfaces of `saga.Mapper` and `saga.Persister` such that the mapper is only responsible for deciding whether the message is mapped to an instance at all, and the persister is responsible for determining whether the instance already exists or not.

The saga handler calls the not-found handler if the persister returns an instance at revision zero but the message is not a trigger.

It so happens that this PR fixes #49 and makes a similar change to the `persistence.MessageStore` interface.