### PR TITLE
Temporarily increase RMQ pre-fetch while holding onto delayed messages before retry.

### DIFF
--- a/src/ax/endpoint/receiver.go
+++ b/src/ax/endpoint/receiver.go
@@ -59,8 +59,8 @@ func (r *receiver) process(
 		return ack.Ack(ctx)
 	}
 
-	if r.RetryPolicy(env, err) {
-		return ack.Retry(ctx, err)
+	if d, ok := r.RetryPolicy(env, err); ok {
+		return ack.Retry(ctx, err, d)
 	}
 
 	return ack.Reject(ctx, err)

--- a/src/ax/endpoint/retry.go
+++ b/src/ax/endpoint/retry.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// RetryPolicy returns is a function responsible for determining whether or not
-// a message should be retried.
+// RetryPolicy is a function responsible for determining whether or not a
+// message should be retried.
 //
-// It returns the delay that occur before retrying, and a bool indicating
+// It returns the delay that should occur before retrying, and a bool indicating
 // whether or not the message should be retried at all.
 type RetryPolicy func(InboundEnvelope, error) (time.Duration, bool)
 

--- a/src/ax/endpoint/retry.go
+++ b/src/ax/endpoint/retry.go
@@ -1,10 +1,55 @@
 package endpoint
 
-// RetryPolicy returns true if the message should be retried.
-type RetryPolicy func(InboundEnvelope, error) bool
+import (
+	"math"
+	"time"
+)
 
-// DefaultRetryPolicy is a RetryPolicy that rejects a message after it has been
-// attempted three (3) times.
-func DefaultRetryPolicy(env InboundEnvelope, _ error) bool {
-	return env.DeliveryCount < 3
+// RetryPolicy returns is a function responsible for determining whether or not
+// a message should be retried.
+//
+// It returns the delay that occur before retrying, and a bool indicating
+// whether or not the message should be retried at all.
+type RetryPolicy func(InboundEnvelope, error) (time.Duration, bool)
+
+// DefaultRetryPolicy is the default RetryPolicy.
+//
+// It allows for 3 immediate attempts, after which each attempt is delayed
+// exponentially, for a maximum of 10 attempts before the message is rejected.
+var DefaultRetryPolicy = NewExponentialBackoffPolicy(3, 10, 1*time.Second)
+
+// NewExponentialBackoffPolicy returns a retry policy that allows a fixed number
+// of immediate attempts after which retries are delayed exponentially for a
+// fixed number of total attempts before the message is rejected.
+//
+// i is the number of immediate attempts. m is the maximum total attempts, and
+// d is a multplier for the backoff duration.
+func NewExponentialBackoffPolicy(i, m uint, d time.Duration) RetryPolicy {
+	return func(env InboundEnvelope, _ error) (time.Duration, bool) {
+		n := env.DeliveryCount
+
+		// Stop retrying if we've reached the maximum number of attempts.
+		if n >= m {
+			return 0, false
+		}
+
+		// If the delivery count is unknown, always retry, but always use the
+		// maximium backoff period.
+		if n == 0 {
+			n = m
+		}
+
+		// Retry immediately if we haven't yet exhausted the immediate attempt limit.
+		if n < i {
+			return 0, true
+		}
+
+		// Otherwise, backoff exponentially.
+		p := math.Pow(
+			2,
+			float64(n-i), // number of non-immediate attempts
+		)
+
+		return time.Duration(p) * d, true
+	}
 }

--- a/src/ax/endpoint/transport.go
+++ b/src/ax/endpoint/transport.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"time"
 
 	"github.com/jmalloc/ax/src/ax"
 )
@@ -50,7 +51,10 @@ type Acknowledger interface {
 
 	// Retry requeues the message so that it is redelivered at some point in the
 	// future.
-	Retry(ctx context.Context, err error) error
+	//
+	// d is a hint as to how long the transport should wait before redelivering
+	// this message.
+	Retry(ctx context.Context, err error, d time.Duration) error
 
 	// Reject indicates that the message could not be handled and should not be
 	// retried. Depending on the transport, this may move the message to some form

--- a/src/axrmq/acknowledger.go
+++ b/src/axrmq/acknowledger.go
@@ -2,6 +2,7 @@ package axrmq
 
 import (
 	"context"
+	"time"
 
 	"github.com/streadway/amqp"
 )
@@ -19,7 +20,10 @@ func (a *Acknowledger) Ack(_ context.Context) error {
 
 // Retry requeues the message so that it is redelivered at some point in the
 // future.
-func (a *Acknowledger) Retry(_ context.Context, _ error) error {
+//
+// d is a hint as to how long the transport should wait before redelivering
+// this message.
+func (a *Acknowledger) Retry(_ context.Context, _ error, _ time.Duration) error {
 	return a.Delivery.Reject(true) // true = requeue
 }
 

--- a/src/axrmq/acknowledger.go
+++ b/src/axrmq/acknowledger.go
@@ -9,13 +9,14 @@ import (
 
 // Acknowledger is an implementation of bus.Acknowledger that acknowledges AMQP messages.
 type Acknowledger struct {
-	Delivery amqp.Delivery
+	con *consumer
+	del amqp.Delivery
 }
 
 // Ack acknowledges the message, indicating that is was handled successfully
 // and does not need to be redelivered.
 func (a *Acknowledger) Ack(_ context.Context) error {
-	return a.Delivery.Ack(false) // false = single message
+	return a.del.Ack(false) // false = single message
 }
 
 // Retry requeues the message so that it is redelivered at some point in the
@@ -23,13 +24,36 @@ func (a *Acknowledger) Ack(_ context.Context) error {
 //
 // d is a hint as to how long the transport should wait before redelivering
 // this message.
-func (a *Acknowledger) Retry(_ context.Context, _ error, _ time.Duration) error {
-	return a.Delivery.Reject(true) // true = requeue
+func (a *Acknowledger) Retry(ctx context.Context, _ error, d time.Duration) error {
+	if d >= 0 {
+		if err := a.delay(ctx, d); err != nil {
+			return err
+		}
+	}
+
+	return a.del.Reject(true) // true = requeue
 }
 
 // Reject indicates that the message could not be handled and should not be
 // retried. Depending on the transport, this may move the message to some form
 // of error queue or otherwise drop the message completely.
 func (a *Acknowledger) Reject(_ context.Context, _ error) error {
-	return a.Delivery.Reject(false) // false = don't requeue
+	return a.del.Reject(false) // false = don't requeue
+}
+
+func (a *Acknowledger) delay(ctx context.Context, d time.Duration) error {
+	if err := a.con.IncreasePreFetch(); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+
+	if err := a.con.DecreasePreFetch(); err != nil {
+		return err
+	}
+
+	return ctx.Err()
 }

--- a/src/axrmq/marshaling.go
+++ b/src/axrmq/marshaling.go
@@ -48,8 +48,6 @@ func unmarshalMessage(del amqp.Delivery) (endpoint.InboundEnvelope, error) {
 	var err error
 	env.Message, err = ax.UnmarshalMessage(del.ContentType, del.Body)
 
-	env.DeliveryCount = countDeliveries(del)
-
 	return env, err
 }
 

--- a/src/axrmq/marshaling.go
+++ b/src/axrmq/marshaling.go
@@ -28,6 +28,7 @@ func marshalMessage(ep string, env endpoint.OutboundEnvelope) (amqp.Publishing, 
 func unmarshalMessage(del amqp.Delivery) (endpoint.InboundEnvelope, error) {
 	env := endpoint.InboundEnvelope{
 		SourceEndpoint: del.AppId,
+		DeliveryCount:  countDeliveries(del),
 	}
 
 	if err := env.MessageID.Parse(del.MessageId); err != nil {
@@ -47,5 +48,44 @@ func unmarshalMessage(del amqp.Delivery) (endpoint.InboundEnvelope, error) {
 	var err error
 	env.Message, err = ax.UnmarshalMessage(del.ContentType, del.Body)
 
+	env.DeliveryCount = countDeliveries(del)
+
 	return env, err
+}
+
+// countDeliveries attempts to return the number of times the given message has
+// been delievered. It returns zero if the count is unknown.
+func countDeliveries(del amqp.Delivery) uint {
+	death, ok := del.Headers["x-death"]
+
+	if !ok {
+		// The message has been redelivered, but there is no x-death header.
+		// This can occur when the AMQP connection drops out without an explicit
+		// rejection. We can't know the actual count in this case.
+		if del.Redelivered {
+			return 0 // unknown count
+		}
+
+		// The message has not been redelivered, and there is no x-death header,
+		// so this must be the first attempt.
+		return 1
+	}
+
+	// the x-death header should contain an AMQP array of AMQP tables.
+	slice, ok := death.([]interface{})
+	if !ok {
+		return 0 // unknown count, unexpected header type
+	}
+
+	// sum the total of the DLX counts
+	var count uint
+	for _, v := range slice {
+		if t, ok := v.(amqp.Table); ok {
+			if n, ok := t["count"].(int64); ok {
+				count += uint(n)
+			}
+		}
+	}
+
+	return count
 }

--- a/src/axrmq/topology.go
+++ b/src/axrmq/topology.go
@@ -58,7 +58,7 @@ func declareQueues(ch *amqp.Channel, ep string) error {
 		false, // noWait
 		amqp.Table{
 			"x-dead-letter-exchange":    "",
-			"x-dead-letter-routing-key": errors,
+			"x-dead-letter-routing-key": pending, // route dead-lettered messages back to the pending queue
 		},
 	); err != nil {
 		return err

--- a/src/axrmq/transport.go
+++ b/src/axrmq/transport.go
@@ -110,7 +110,7 @@ func (t *Transport) Receive(ctx context.Context) (env endpoint.InboundEnvelope, 
 
 		env, err = unmarshalMessage(del)
 		if err == nil {
-			ack = &Acknowledger{del}
+			ack = &Acknowledger{t.con, del}
 			return
 		}
 
@@ -132,7 +132,7 @@ func (t *Transport) startConsumer() error {
 		preFetch = DefaultReceiveConcurrency
 	}
 
-	con, err := newConsumer(t.Conn, t.ep, t.Exclusive, preFetch)
+	con, err := newConsumer(t.Conn, t.ep, t.Exclusive, preFetch, preFetch*10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This does address #31, but still doesn't help that much without knowing how many times the message has been delivered.

@danilvpetrov can you think of a way (probably with DLX) that we can get a redelivery count from RMQ without introducing a delay between retries at the transport layer itself?