### PR TITLE
Return an error if a single-row mutation does not affect exactly one row.

### DIFF
--- a/src/ax/projection/consumer.go
+++ b/src/ax/projection/consumer.go
@@ -80,12 +80,11 @@ func (c *GlobalStoreConsumer) processNextMessage(ctx context.Context) error {
 		return err
 	}
 
-	err = c.Offsets.SaveOffset(
+	err = c.Offsets.IncrementOffset(
 		ctx,
 		tx,
 		c.key,
 		o,
-		o+1,
 	)
 	if err != nil {
 		return err

--- a/src/ax/projection/offsetstore.go
+++ b/src/ax/projection/offsetstore.go
@@ -19,16 +19,16 @@ type OffsetStore interface {
 		pk string,
 	) (uint64, error)
 
-	// SaveOffset stores the next offset at which a consumer should resume
-	// reading from the stream.
+	// IncrementOffset increments the offset at which a consumer should resume
+	// reading from the stream by one.
 	//
 	// pk is the projector's persitence key. c is the offset that is currently
 	// stored, as returned by LoadOffset(). If c is not the offset that is
-	// currently stored, a non-nil error is returned. o is the new offset to store.
-	SaveOffset(
+	// currently stored, the increment fails and a non-nil error is returned.
+	IncrementOffset(
 		ctx context.Context,
 		tx persistence.Tx,
 		pk string,
-		c, o uint64,
+		c uint64,
 	) error
 }

--- a/src/axmysql/internal/sqlutil/error.go
+++ b/src/axmysql/internal/sqlutil/error.go
@@ -1,0 +1,22 @@
+package sqlutil
+
+import (
+	"github.com/go-sql-driver/mysql"
+)
+
+const (
+	mysqlDupEntry = 1062 // https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_dup_entry
+	mysqlDeadLock = 1213 // https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_lock_deadlock
+)
+
+// IsDuplicateEntry returns true if err represents a MySQL duplicate entry error.
+func IsDuplicateEntry(err error) bool {
+	e, ok := err.(*mysql.MySQLError)
+	return ok && e.Number == mysqlDupEntry
+}
+
+// IsDeadlock returns true if err represents a MySQL deadlock condition.
+func IsDeadlock(err error) bool {
+	e, ok := err.(*mysql.MySQLError)
+	return ok && e.Number == mysqlDeadLock
+}

--- a/src/axmysql/internal/sqlutil/exec.go
+++ b/src/axmysql/internal/sqlutil/exec.go
@@ -7,7 +7,10 @@ import (
 )
 
 // ExecSingleRow executes a query without returning any rows and verifies that
-// only a single row was affected.
+// exactly one row was affected.
+//
+// For an UPDATE query, this means that the query must actually alter the row,
+// not simply match one row.
 //
 // The args are for any placeholder parameters in the query. It returns an error
 // if more than one row was affected.
@@ -32,4 +35,29 @@ func ExecSingleRow(
 	}
 
 	return nil
+}
+
+// ExecInsertOrUpdate executes a MySQL "INSERT ... ON DUPLICATE KEY UPDATE"
+// query, and returns true if it results in an insert.
+func ExecInsertOrUpdate(
+	ctx context.Context,
+	tx *sql.Tx,
+	query string,
+	args ...interface{},
+) (bool, error) {
+	res, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+
+	// https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+	//
+	// From the MySQL docs:
+	//
+	// With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the
+	// row is inserted as a new row, 2 if an existing row is updated, and 0 if an
+	// existing row is set to its current values.
+	n, err := res.RowsAffected()
+
+	return n == 1, err
 }

--- a/src/axmysql/internal/sqlutil/exec.go
+++ b/src/axmysql/internal/sqlutil/exec.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 )
 
-// UpdateSingleRow executes a query without returning any rows and verifies that
+// ExecSingleRow executes a query without returning any rows and verifies that
 // only a single row was affected.
 //
 // The args are for any placeholder parameters in the query. It returns an error
 // if more than one row was affected.
-func UpdateSingleRow(
+func ExecSingleRow(
 	ctx context.Context,
 	tx *sql.Tx,
 	query string,
@@ -28,7 +28,7 @@ func UpdateSingleRow(
 	}
 
 	if n != 1 {
-		return fmt.Errorf("update to single row affected %d rows", n)
+		return fmt.Errorf("execution of query on single row actually affected %d rows", n)
 	}
 
 	return nil

--- a/src/axmysql/internal/sqlutil/update.go
+++ b/src/axmysql/internal/sqlutil/update.go
@@ -6,18 +6,18 @@ import (
 	"fmt"
 )
 
-// UpdateSingleRow performs an update and verifies that only a single row was
-// updated.
+// UpdateSingleRow executes a query without returning any rows and verifies that
+// only a single row was affected.
 //
-// q is the SQL update statement to execute. v is the variable arguments to pass
-// along to the execute statement.
+// The args are for any placeholder parameters in the query. It returns an error
+// if more than one row was affected.
 func UpdateSingleRow(
 	ctx context.Context,
 	tx *sql.Tx,
-	q string,
-	v ...interface{},
+	query string,
+	args ...interface{},
 ) error {
-	res, err := tx.ExecContext(ctx, q, v...)
+	res, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}

--- a/src/axmysql/internal/sqlutil/update.go
+++ b/src/axmysql/internal/sqlutil/update.go
@@ -1,0 +1,35 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// UpdateSingleRow performs an update and verifies that only a single row was
+// updated.
+//
+// q is the SQL update statement to execute. v is the variable arguments to pass
+// along to the execute statement.
+func UpdateSingleRow(
+	ctx context.Context,
+	tx *sql.Tx,
+	q string,
+	v ...interface{},
+) error {
+	res, err := tx.ExecContext(ctx, q, v...)
+	if err != nil {
+		return err
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if n != 1 {
+		return fmt.Errorf("update to single row affected %d rows", n)
+	}
+
+	return nil
+}

--- a/src/axmysql/messagestore/append.go
+++ b/src/axmysql/messagestore/append.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jmalloc/ax/src/ax"
+	"github.com/jmalloc/ax/src/axmysql/internal/sqlutil"
 )
 
 // insertStream inserts a new stream and returns its ID.
@@ -76,14 +77,18 @@ func incrStreamOffset(
 		)
 	}
 
-	_, err = tx.ExecContext(
+	err = sqlutil.UpdateSingleRow(
 		ctx,
+		tx,
 		`UPDATE ax_messagestore_stream SET
 			next = next + ?
 		WHERE stream_id = ?`,
 		n,
 		id,
 	)
+	if err != nil {
+		return 0, err
+	}
 
 	return id, err
 }

--- a/src/axmysql/messagestore/append.go
+++ b/src/axmysql/messagestore/append.go
@@ -3,7 +3,6 @@ package messagestore
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/jmalloc/ax/src/ax"
@@ -13,12 +12,13 @@ import (
 // insertStream inserts a new stream and returns its ID.
 //
 // s is the name of the stream, n is the initial value of the "next" offset.
+// It returns false if there is already a stream by this name.
 func insertStream(
 	ctx context.Context,
 	tx *sql.Tx,
 	s string,
 	n uint64,
-) (int64, error) {
+) (int64, bool, error) {
 	res, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO ax_messagestore_stream SET
@@ -28,23 +28,28 @@ func insertStream(
 		n,
 	)
 	if err != nil {
-		return 0, err
+		if sqlutil.IsDuplicateEntry(err) {
+			return 0, false, nil
+		}
+
+		return 0, false, err
 	}
 
-	return res.LastInsertId()
+	id, err := res.LastInsertId()
+	return id, true, err
 }
 
 // incrStreamOffset increments the offset for the given stream by n.
 //
 // s is the name of the stream. It returns the stream's ID.
-// It returns an error if o is not the next free offset.
+// It returns false if o is not the next free offset.
 func incrStreamOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	s string,
 	o uint64,
 	n uint64,
-) (int64, error) {
+) (int64, bool, error) {
 	var (
 		id   int64
 		next uint64
@@ -64,20 +69,17 @@ func incrStreamOffset(
 		&next,
 	)
 
-	if err != nil && err != sql.ErrNoRows {
-		return 0, err
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	} else if err != nil {
+		return 0, false, err
 	}
 
 	if o != next {
-		return 0, fmt.Errorf(
-			"can not append to stream %s, %d is not the next free offset, expected %d",
-			s,
-			o,
-			next,
-		)
+		return 0, false, nil
 	}
 
-	err = sqlutil.ExecSingleRow(
+	return id, true, sqlutil.ExecSingleRow(
 		ctx,
 		tx,
 		`UPDATE ax_messagestore_stream SET
@@ -86,11 +88,6 @@ func incrStreamOffset(
 		n,
 		id,
 	)
-	if err != nil {
-		return 0, err
-	}
-
-	return id, err
 }
 
 // incrGlobalOffset increments the global stream offset by n.
@@ -102,10 +99,11 @@ func incrGlobalOffset(
 	n uint64,
 ) (uint64, error) {
 	// insert or update both cause the row to be locked in tx
-	res, err := tx.ExecContext(
+	inserted, err := sqlutil.ExecInsertOrUpdate(
 		ctx,
+		tx,
 		`INSERT INTO ax_messagestore_offset SET
-			 	next = ?
+			next = ?
 		ON DUPLICATE KEY UPDATE
 			next = next + VALUE(next)`,
 		n,
@@ -114,14 +112,7 @@ func incrGlobalOffset(
 		return 0, nil
 	}
 
-	ar, err := res.RowsAffected()
-	if err != nil {
-		return 0, nil
-	}
-
-	if ar == 1 {
-		// if MySQL reports rows affected as 1, that means an insert occurred
-		// so we know that the offset was 0
+	if inserted {
 		return 0, nil
 	}
 

--- a/src/axmysql/messagestore/append.go
+++ b/src/axmysql/messagestore/append.go
@@ -77,7 +77,7 @@ func incrStreamOffset(
 		)
 	}
 
-	err = sqlutil.UpdateSingleRow(
+	err = sqlutil.ExecSingleRow(
 		ctx,
 		tx,
 		`UPDATE ax_messagestore_stream SET

--- a/src/axmysql/outbox/repository.go
+++ b/src/axmysql/outbox/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jmalloc/ax/src/ax"
 	"github.com/jmalloc/ax/src/ax/endpoint"
 	"github.com/jmalloc/ax/src/ax/persistence"
+	"github.com/jmalloc/ax/src/axmysql/internal/sqlutil"
 	mysqlpersistence "github.com/jmalloc/ax/src/axmysql/persistence"
 )
 
@@ -107,12 +108,12 @@ func (Repository) MarkAsSent(
 	ptx persistence.Tx,
 	env endpoint.OutboundEnvelope,
 ) error {
-	_, err := mysqlpersistence.ExtractTx(ptx).ExecContext(
+	return sqlutil.ExecSingleRow(
 		ctx,
+		mysqlpersistence.ExtractTx(ptx),
 		`DELETE FROM ax_outbox_message WHERE message_id = ?`,
 		env.MessageID,
 	)
-	return err
 }
 
 func scanOutboxMessage(rows *sql.Rows, causationID ax.MessageID) (endpoint.OutboundEnvelope, error) {

--- a/src/axmysql/projection/offsetstore.go
+++ b/src/axmysql/projection/offsetstore.go
@@ -123,7 +123,7 @@ func (OffsetStore) updateOffset(
 		FROM ax_projection_offset
 		WHERE persistence_key = ?
 		FOR UPDATE`,
-		pn,
+		pk,
 	).Scan(
 		&current,
 	)

--- a/src/axmysql/projection/offsetstore.go
+++ b/src/axmysql/projection/offsetstore.go
@@ -98,7 +98,7 @@ func (OffsetStore) SaveOffset(
 		)
 	}
 
-	return sqlutil.UpdateSingleRow(
+	return sqlutil.ExecSingleRow(
 		ctx,
 		tx,
 		`UPDATE ax_projection_offset SET

--- a/src/axmysql/projection/offsetstore.go
+++ b/src/axmysql/projection/offsetstore.go
@@ -128,11 +128,9 @@ func (OffsetStore) updateOffset(
 		&current,
 	)
 
-	if err != sql.ErrNoRows {
+	if err == sql.ErrNoRows {
 		return false, nil
-	}
-
-	if err != nil {
+	} else if err != nil {
 		return false, err
 	}
 

--- a/src/axmysql/projection/offsetstore.go
+++ b/src/axmysql/projection/offsetstore.go
@@ -3,9 +3,9 @@ package projection
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/jmalloc/ax/src/ax/persistence"
+	"github.com/jmalloc/ax/src/axmysql/internal/sqlutil"
 	mysqlpersistence "github.com/jmalloc/ax/src/axmysql/persistence"
 )
 
@@ -73,8 +73,9 @@ func (OffsetStore) SaveOffset(
 		return err
 	}
 
-	res, err := tx.ExecContext(
+	return sqlutil.UpdateSingleRow(
 		ctx,
+		tx,
 		`UPDATE ax_projection_offset SET
 			next_offset = ?
 		WHERE persistence_key = ?
@@ -83,22 +84,4 @@ func (OffsetStore) SaveOffset(
 		pk,
 		c,
 	)
-	if err != nil {
-		return err
-	}
-
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	if n == 0 {
-		return fmt.Errorf(
-			"can not store offset for %s projection, offset %d is not the currently stored offset",
-			pk,
-			c,
-		)
-	}
-
-	return err
 }

--- a/src/axmysql/projection/offsetstore.go
+++ b/src/axmysql/projection/offsetstore.go
@@ -47,34 +47,75 @@ func (OffsetStore) LoadOffset(
 	return offset, nil
 }
 
-// SaveOffset stores the next offset at which a consumer should resume
-// reading from the stream.
+// IncrementOffset increments the offset at which a consumer should resume
+// reading from the stream by one.
 //
 // pk is the projector's persitence key. c is the offset that is currently
 // stored, as returned by LoadOffset(). If c is not the offset that is
-// currently stored, a non-nil error is returned. o is the new offset to store.
-func (OffsetStore) SaveOffset(
+// currently stored, the increment fails and a non-nil error is returned.
+func (s OffsetStore) IncrementOffset(
 	ctx context.Context,
 	ptx persistence.Tx,
 	pk string,
-	c, o uint64,
+	c uint64,
 ) error {
 	tx := mysqlpersistence.ExtractTx(ptx)
 
-	if c == 0 {
-		_, err := tx.ExecContext(
-			ctx,
-			`INSERT INTO ax_projection_offset SET
-				persistence_key = ?,
-				next_offset = ?`,
-			pk,
-			o,
-		)
+	var (
+		ok  bool
+		err error
+	)
 
+	if c == 0 {
+		ok, err = s.insertOffset(ctx, tx, pk)
+	} else {
+		ok, err = s.updateOffset(ctx, tx, pk, c)
+	}
+
+	if ok || err != nil {
 		return err
 	}
 
-	var no uint64
+	// TODO: use OCC error https://github.com/jmalloc/ax/issues/93
+	return fmt.Errorf(
+		"can not increment projection offset for persistence key %s, offset %d is not the current offset",
+		pk,
+		c,
+	)
+}
+
+// insertOffset inserts an entry for the saga pk with the offset set to 1.
+// It returns false if an entry already exists.
+func (OffsetStore) insertOffset(
+	ctx context.Context,
+	tx *sql.Tx,
+	pk string,
+) (bool, error) {
+	_, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO ax_projection_offset SET
+			persistence_key = ?,
+			next_offset = 1`,
+		pk,
+	)
+
+	if sqlutil.IsDuplicateEntry(err) {
+		return false, nil
+	}
+
+	return true, err
+}
+
+// updateOffset increments the entry for the saga pk.
+// It returns false if c is not the currently stored offset.
+func (OffsetStore) updateOffset(
+	ctx context.Context,
+	tx *sql.Tx,
+	pk string,
+	c uint64,
+) (bool, error) {
+	var current uint64
+
 	err := tx.QueryRowContext(
 		ctx,
 		`SELECT
@@ -84,29 +125,27 @@ func (OffsetStore) SaveOffset(
 		FOR UPDATE`,
 		pn,
 	).Scan(
-		&no,
+		&current,
 	)
+
+	if err != sql.ErrNoRows {
+		return false, nil
+	}
+
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	if o != no {
-		return fmt.Errorf(
-			"can not update projection offset for persistence key %s, offset %d is not the next offset",
-			pn,
-			o,
-		)
+	if c != current {
+		return false, nil
 	}
 
-	return sqlutil.ExecSingleRow(
+	return true, sqlutil.ExecSingleRow(
 		ctx,
 		tx,
 		`UPDATE ax_projection_offset SET
-			next_offset = ?
-		WHERE persistence_key = ?
-		AND next_offset = ?`,
-		o,
+			next_offset = next_offset + 1
+		WHERE persistence_key = ?`,
 		pk,
-		c,
 	)
 }

--- a/src/axmysql/saga/crud.go
+++ b/src/axmysql/saga/crud.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmalloc/ax/src/ax/persistence"
 	"github.com/jmalloc/ax/src/ax/saga"
+	"github.com/jmalloc/ax/src/axmysql/internal/sqlutil"
 	mysqlpersistence "github.com/jmalloc/ax/src/axmysql/persistence"
 )
 
@@ -188,8 +189,9 @@ func (CRUDRepository) updateInstance(
 		)
 	}
 
-	res, err := tx.ExecContext(
+	return sqlutil.UpdateSingleRow(
 		ctx,
+		tx,
 		`UPDATE ax_saga_instance SET
 			revision = revision + 1,
 			description = ?,
@@ -201,22 +203,4 @@ func (CRUDRepository) updateInstance(
 		data,
 		i.InstanceID,
 	)
-	if err != nil {
-		return err
-	}
-
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	if n == 0 {
-		return fmt.Errorf(
-			"no rows affected when updating saga instance %s at revision %d",
-			i.InstanceID,
-			i.Revision,
-		)
-	}
-
-	return nil
 }

--- a/src/axmysql/saga/crud.go
+++ b/src/axmysql/saga/crud.go
@@ -189,7 +189,7 @@ func (CRUDRepository) updateInstance(
 		)
 	}
 
-	return sqlutil.UpdateSingleRow(
+	return sqlutil.ExecSingleRow(
 		ctx,
 		tx,
 		`UPDATE ax_saga_instance SET

--- a/src/axmysql/saga/snapshot.go
+++ b/src/axmysql/saga/snapshot.go
@@ -24,14 +24,16 @@ func (SnapshotRepository) LoadSagaSnapshot(
 	pk string,
 	id saga.InstanceID,
 ) (saga.Instance, bool, error) {
+	tx := mysqlpersistence.ExtractTx(ptx)
+
 	var (
-		ipk         string
+		cpk         string
 		i           saga.Instance
 		contentType string
 		data        []byte
 	)
 
-	err := mysqlpersistence.ExtractTx(ptx).QueryRowContext(
+	err := tx.QueryRowContext(
 		ctx,
 		`SELECT
 			instance_id,
@@ -47,26 +49,24 @@ func (SnapshotRepository) LoadSagaSnapshot(
 	).Scan(
 		&i.InstanceID,
 		&i.Revision,
-		&ipk,
+		&cpk,
 		&contentType,
 		&data,
 	)
 
 	if err == sql.ErrNoRows {
 		return saga.Instance{}, false, nil
-	}
-
-	if err != nil {
+	} else if err != nil {
 		return saga.Instance{}, false, nil
 	}
 
-	if ipk != pk {
+	if cpk != pk {
 		return i, false, fmt.Errorf(
 			"can not load saga snapshot of %s at revision %d for saga %s, it belongs to %s",
 			i.InstanceID,
 			i.Revision,
 			pk,
-			ipk,
+			cpk,
 		)
 	}
 
@@ -81,16 +81,18 @@ func (SnapshotRepository) LoadSagaSnapshot(
 // existing snapshots of the same instance.
 func (SnapshotRepository) SaveSagaSnapshot(
 	ctx context.Context,
-	tx persistence.Tx,
+	ptx persistence.Tx,
 	pk string,
 	i saga.Instance,
 ) error {
+	tx := mysqlpersistence.ExtractTx(ptx)
+
 	contentType, data, err := saga.MarshalData(i.Data)
 	if err != nil {
 		return err
 	}
 
-	_, err = mysqlpersistence.ExtractTx(tx).ExecContext(
+	_, err = tx.ExecContext(
 		ctx,
 		`INSERT INTO ax_saga_snapshot SET
 			instance_id = ?,


### PR DESCRIPTION
Fixes #100

Also provides better context in the face of duplicate errors and general improvements to MySQL error handling.