### PR TITLE
Further improvements to message logging.

### DIFF
--- a/src/ax/endpoint/context.go
+++ b/src/ax/endpoint/context.go
@@ -2,13 +2,11 @@ package endpoint
 
 import (
 	"context"
-
-	"github.com/jmalloc/ax/src/ax"
 )
 
 // WithEnvelope returns a new context derived from p that contains env.
 // The envelope can be retreived from the context with GetEnvelope().
-func WithEnvelope(p context.Context, env ax.Envelope) context.Context {
+func WithEnvelope(p context.Context, env InboundEnvelope) context.Context {
 	return context.WithValue(
 		p,
 		envelopeKey,
@@ -18,11 +16,11 @@ func WithEnvelope(p context.Context, env ax.Envelope) context.Context {
 
 // GetEnvelope returns the message envelope contained in ctx.
 // If ctx does not contain an envelope then ok is false.
-func GetEnvelope(ctx context.Context) (env ax.Envelope, ok bool) {
+func GetEnvelope(ctx context.Context) (env InboundEnvelope, ok bool) {
 	v := ctx.Value(envelopeKey)
 
 	if v != nil {
-		env, ok = v.(ax.Envelope)
+		env, ok = v.(InboundEnvelope)
 	}
 
 	return

--- a/src/ax/endpoint/context_test.go
+++ b/src/ax/endpoint/context_test.go
@@ -12,7 +12,9 @@ import (
 
 var _ = Describe("WithEnvelope / GetEnvelope", func() {
 	It("transports a message envelope via the context", func() {
-		expected := ax.NewEnvelope(&testmessages.Message{})
+		expected := InboundEnvelope{
+			Envelope: ax.NewEnvelope(&testmessages.Message{}),
+		}
 		ctx := WithEnvelope(context.Background(), expected)
 
 		env, ok := GetEnvelope(ctx)

--- a/src/ax/endpoint/envelope.go
+++ b/src/ax/endpoint/envelope.go
@@ -5,30 +5,30 @@ import (
 	"github.com/jmalloc/ax/src/ax/ident"
 )
 
-// DeliveryID uniquely identifies an attempt to process a message.
-type DeliveryID struct {
+// AttemptID uniquely identifies an attempt to process a message.
+type AttemptID struct {
 	ident.ID
 }
 
-// GenerateDeliveryID generates a new unique identifier for a delivery.
-func GenerateDeliveryID() DeliveryID {
-	var id DeliveryID
+// GenerateAttemptID generates a new unique identifier for a processing attempt.
+func GenerateAttemptID() AttemptID {
+	var id AttemptID
 	id.GenerateUUID()
 	return id
 }
 
-// ParseDeliveryID parses s into a delivery ID and returns it. It returns an
+// ParseAttemptID parses s into an attempt ID and returns it. It returns an
 // error if s is empty.
-func ParseDeliveryID(s string) (DeliveryID, error) {
-	var id DeliveryID
+func ParseAttemptID(s string) (AttemptID, error) {
+	var id AttemptID
 	err := id.Parse(s)
 	return id, err
 }
 
-// MustParseDeliveryID parses s into a delivery ID and returns it. It panics if
+// MustParseAttemptID parses s into an attempt ID and returns it. It panics if
 // s is empty.
-func MustParseDeliveryID(s string) DeliveryID {
-	var id DeliveryID
+func MustParseAttemptID(s string) AttemptID {
+	var id AttemptID
 	id.MustParse(s)
 	return id
 }
@@ -43,18 +43,19 @@ type InboundEnvelope struct {
 	// SourceEndpoint is the endpoint that sent the message.
 	SourceEndpoint string
 
-	// DeliveryID uniquely identifies the attempt to process this message.
-	DeliveryID DeliveryID
+	// AttemptID uniquely identifies the attempt to process this message.
+	AttemptID AttemptID
 
-	// DeliveryCount is the number of times that this message has been delivered.
+	// AttemptCount is the number of times that an attempt has been made to process
+	// this message.
 	//
-	// Messages may be redelivered after a failure handling the message, or if
-	// an endpoint crashes, for example. Not all transports support a delivery
-	// count, in which case the count is zero.
+	// Messages may be retried after a failure handling the message, or if
+	// an endpoint crashes, for example. Not all transports support an attempt
+	// count. If the attempt count is unknown, it is set to zero.
 	//
-	// The delivery count may be reset if a message is manually re-queued after
+	// The attempt count may be reset if a message is manually re-queued after
 	// being rejected by the retry policy.
-	DeliveryCount uint
+	AttemptCount uint
 }
 
 // OutboundEnvelope is a specialization of ax.Envelope for messages that are

--- a/src/ax/endpoint/receiver.go
+++ b/src/ax/endpoint/receiver.go
@@ -53,7 +53,11 @@ func (r *receiver) process(
 	env InboundEnvelope,
 	ack Acknowledger,
 ) error {
-	err := r.In.Accept(ctx, r.Out, env)
+	err := r.In.Accept(
+		WithEnvelope(ctx, env),
+		r.Out,
+		env,
+	)
 
 	if err == nil {
 		return ack.Ack(ctx)

--- a/src/ax/endpoint/retry.go
+++ b/src/ax/endpoint/retry.go
@@ -26,14 +26,14 @@ var DefaultRetryPolicy = NewExponentialBackoffPolicy(3, 10, 1*time.Second)
 // d is a multplier for the backoff duration.
 func NewExponentialBackoffPolicy(i, m uint, d time.Duration) RetryPolicy {
 	return func(env InboundEnvelope, _ error) (time.Duration, bool) {
-		n := env.DeliveryCount
+		n := env.AttemptCount
 
 		// Stop retrying if we've reached the maximum number of attempts.
 		if n >= m {
 			return 0, false
 		}
 
-		// If the delivery count is unknown, always retry, but always use the
+		// If the attempt count is unknown, always retry, but always use the
 		// maximium backoff period.
 		if n == 0 {
 			n = m

--- a/src/ax/endpoint/sender.go
+++ b/src/ax/endpoint/sender.go
@@ -86,7 +86,7 @@ func (s SinkSender) newEnvelope(ctx context.Context, m ax.Message) (ax.Envelope,
 	}
 
 	if env, ok := GetEnvelope(ctx); ok {
-		return env.NewChild(m), nil
+		return env.Envelope.NewChild(m), nil
 	}
 
 	return ax.NewEnvelope(m), nil

--- a/src/ax/endpoint/sender_test.go
+++ b/src/ax/endpoint/sender_test.go
@@ -58,7 +58,9 @@ var _ = Describe("SinkSender", func() {
 		})
 
 		It("configures the outbound message as a child of the envelope in ctx", func() {
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 
 			_, _ = sender.ExecuteCommand(ctx, &testmessages.Command{})
@@ -79,7 +81,9 @@ var _ = Describe("SinkSender", func() {
 				return expected
 			}
 
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 
 			_, err := sender.ExecuteCommand(ctx, &testmessages.Command{})
@@ -92,7 +96,9 @@ var _ = Describe("SinkSender", func() {
 				Sink: sink,
 			}
 
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 			_, err := sender.ExecuteCommand(
 				ctx,
@@ -106,7 +112,9 @@ var _ = Describe("SinkSender", func() {
 			sender = SinkSender{
 				Sink: sink,
 			}
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 			_, err := sender.ExecuteCommand(
 				ctx,
@@ -128,7 +136,9 @@ var _ = Describe("SinkSender", func() {
 		})
 
 		It("configures the outbound message as a child of the envelope in ctx", func() {
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 
 			_, _ = sender.PublishEvent(ctx, &testmessages.Event{})
@@ -149,7 +159,9 @@ var _ = Describe("SinkSender", func() {
 				return expected
 			}
 
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 
 			_, err := sender.PublishEvent(ctx, &testmessages.Event{})
@@ -162,7 +174,9 @@ var _ = Describe("SinkSender", func() {
 				Sink: sink,
 			}
 
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 			_, err := sender.PublishEvent(
 				ctx,
@@ -176,7 +190,9 @@ var _ = Describe("SinkSender", func() {
 			sender = SinkSender{
 				Sink: sink,
 			}
-			env := ax.NewEnvelope(&testmessages.Message{})
+			env := InboundEnvelope{
+				Envelope: ax.NewEnvelope(&testmessages.Message{}),
+			}
 			ctx := WithEnvelope(context.Background(), env)
 			_, err := sender.PublishEvent(
 				ctx,

--- a/src/ax/endpoint/transport.go
+++ b/src/ax/endpoint/transport.go
@@ -52,13 +52,13 @@ func (s *TransportStage) Accept(ctx context.Context, env OutboundEnvelope) error
 // Acknowledger is an interface for acknowledging a specific inbound message.
 type Acknowledger interface {
 	// Ack acknowledges the message, indicating that is was handled successfully
-	// and does not need to be redelivered.
+	// and does not need to be retried.
 	Ack(ctx context.Context) error
 
-	// Retry requeues the message so that it is redelivered at some point in the
+	// Retry requeues the message so that it is retried at some point in the
 	// future.
 	//
-	// d is a hint as to how long the transport should wait before redelivering
+	// d is a hint as to how long the transport should wait before retrying
 	// this message.
 	Retry(ctx context.Context, err error, d time.Duration) error
 

--- a/src/ax/observability/logging.go
+++ b/src/ax/observability/logging.go
@@ -2,7 +2,9 @@ package observability
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/jmalloc/ax/src/ax"
 	"github.com/jmalloc/ax/src/ax/endpoint"
 	"github.com/jmalloc/twelf/src/twelf"
 )
@@ -14,69 +16,84 @@ type LoggingObserver struct {
 
 // BeforeInbound logs information about an inbound message.
 func (o *LoggingObserver) BeforeInbound(ctx context.Context, env endpoint.InboundEnvelope) {
-	o.log(
-		"recv: %s  [%s msg:%s cause:%s corr:%s del:%s#%d]",
-		env.Message.MessageDescription(),
-		env.Type(),
-		env.MessageID,
-		env.CausationID,
-		env.CorrelationID,
-		env.DeliveryID,
-		env.DeliveryCount,
-	)
+	o.logMessage(ctx, "▼", env.Envelope)
 }
 
 // AfterInbound logs information about errors that occur processing an inbound message.
 func (o *LoggingObserver) AfterInbound(ctx context.Context, env endpoint.InboundEnvelope, err error) {
 	if err != nil {
-		o.log(
-			"recv error: %s  %s  [%s msg:%s cause:%s corr:%s del:%s#%d]",
-			env.Message.MessageDescription(),
-			err,
-			env.Type(),
-			env.MessageID,
-			env.CausationID,
-			env.CorrelationID,
-			env.DeliveryID,
-			env.DeliveryCount,
-		)
+		o.logError(ctx, "▽", env.Envelope, err)
 	}
 }
 
 // BeforeOutbound logs information about an outbound message.
 func (o *LoggingObserver) BeforeOutbound(ctx context.Context, env endpoint.OutboundEnvelope) {
-	o.log(
-		"send: %s  [%s msg:%s cause:%s corr:%s]",
-		env.Message.MessageDescription(),
-		env.Type(),
-		env.MessageID,
-		env.CausationID,
-		env.CorrelationID,
-	)
+	o.logMessage(ctx, "▲", env.Envelope)
 }
 
 // AfterOutbound logs information about an outbound message.
 func (o *LoggingObserver) AfterOutbound(ctx context.Context, env endpoint.OutboundEnvelope, err error) {
 	if err != nil {
-		o.log(
-			"send error: %s  %s  [%s msg:%s cause:%s corr:%s]",
-			env.Message.MessageDescription(),
-			err,
-			env.Type(),
-			env.MessageID,
-			env.CausationID,
-			env.CorrelationID,
-		)
+		o.logError(ctx, "△", env.Envelope, err)
 	}
 }
 
 // log writes a message to o.Logger. If o.Logger is nil, it uses twelf.DefaultLogger.
-func (o *LoggingObserver) log(f string, v ...interface{}) {
+func (o *LoggingObserver) log(s string) {
 	l := o.Logger
 
 	if l == nil {
 		l = twelf.DefaultLogger
 	}
 
-	l.Log(f, v...)
+	l.LogString(s)
+}
+
+func (o *LoggingObserver) logMessage(ctx context.Context, icon string, env ax.Envelope) {
+	s := fmt.Sprintf(
+		"%s   %s  %s",
+		icon,
+		env.Message.MessageDescription(),
+		formatEnvelope(env),
+	)
+
+	if in, ok := endpoint.GetEnvelope(ctx); ok {
+		s += " " + formatAttempt(in)
+	}
+
+	o.log(s)
+}
+
+func (o *LoggingObserver) logError(ctx context.Context, icon string, env ax.Envelope, err error) {
+	s := fmt.Sprintf(
+		"%s ✘ %s ∎ %s  %s",
+		icon,
+		env.Message.MessageDescription(),
+		err,
+		formatEnvelope(env),
+	)
+
+	if in, ok := endpoint.GetEnvelope(ctx); ok {
+		s += " " + formatAttempt(in)
+	}
+
+	o.log(s)
+}
+
+func formatEnvelope(env ax.Envelope) string {
+	return fmt.Sprintf(
+		"[%s msg:%s cause:%s corr:%s]",
+		env.Type(),
+		env.MessageID,
+		env.CausationID,
+		env.CorrelationID,
+	)
+}
+
+func formatAttempt(env endpoint.InboundEnvelope) string {
+	return fmt.Sprintf(
+		"[attempt:%s #%d]",
+		env.AttemptID,
+		env.AttemptCount,
+	)
 }

--- a/src/ax/outbox/deduplicator.go
+++ b/src/ax/outbox/deduplicator.go
@@ -25,9 +25,9 @@ func (d *Deduplicator) Initialize(ctx context.Context, ep *endpoint.Endpoint) er
 }
 
 // Accept passes env to the next pipeline stage only if it has not been
-// delivered previously.
+// processed previously.
 //
-// If it has been delivered previously, the messages that were produced the
+// If it has been processed previously, the messages that were produced the
 // first time are sent using s.
 func (d *Deduplicator) Accept(ctx context.Context, s endpoint.MessageSink, env endpoint.InboundEnvelope) error {
 	ds, ok := persistence.GetDataStore(ctx)

--- a/src/ax/outbox/repository.go
+++ b/src/ax/outbox/repository.go
@@ -12,9 +12,9 @@ import (
 // comprise an incoming message's outbox.
 type Repository interface {
 	// LoadOutbox loads the unsent outbound messages that were produced when the
-	// message identified by id was first delivered.
+	// message identified by id was first processed.
 	//
-	// ok is false if the message has not yet been successfully delivered.
+	// ok is false if the message has not yet been successfully processed.
 	LoadOutbox(
 		ctx context.Context,
 		ds persistence.DataStore,
@@ -22,7 +22,7 @@ type Repository interface {
 	) (envs []endpoint.OutboundEnvelope, ok bool, err error)
 
 	// SaveOutbox saves a set of unsent outbound messages that were produced
-	// when the message identified by id was delivered.
+	// when the message identified by id was processed.
 	SaveOutbox(
 		ctx context.Context,
 		tx persistence.Tx,

--- a/src/ax/projection/projector.go
+++ b/src/ax/projection/projector.go
@@ -24,7 +24,7 @@ type Projector interface {
 	MessageTypes() ax.MessageTypeSet
 
 	// ApplyMessage invokes application-defined logic that updates the
-	// application state to reflect the delivery of a message.
+	// application state to reflect the occurrence of a message.
 	//
 	// It may panic if env.Message is not one of the types described by
 	// MessageTypes().

--- a/src/ax/routing/dispatcher.go
+++ b/src/ax/routing/dispatcher.go
@@ -48,8 +48,6 @@ func (d *Dispatcher) Initialize(ctx context.Context, ep *endpoint.Endpoint) erro
 //
 // Each message handler is invoked on its own goroutine.
 func (d *Dispatcher) Accept(ctx context.Context, s endpoint.MessageSink, env endpoint.InboundEnvelope) error {
-	ctx = endpoint.WithEnvelope(ctx, env.Envelope)
-
 	sender := endpoint.SinkSender{
 		Sink:       s,
 		Validators: d.validators,

--- a/src/ax/routing/dispatcher_test.go
+++ b/src/ax/routing/dispatcher_test.go
@@ -116,23 +116,6 @@ var _ = Describe("Dispatcher", func() {
 			Expect(h3.HandleMessageCalls()).To(HaveLen(0))
 		})
 
-		It("uses a context that contains the message envelope", func() {
-			h1.HandleMessageFunc = func(ctx context.Context, _ ax.Sender, _ ax.MessageContext) error {
-				defer GinkgoRecover()
-
-				e, ok := endpoint.GetEnvelope(ctx)
-
-				Expect(ok).To(BeTrue())
-				Expect(e).To(BeIdenticalTo(env.Envelope))
-
-				return nil
-			}
-
-			_ = dispatcher.Accept(ctx, sink, env)
-
-			Expect(h1.HandleMessageCalls()).To(HaveLen(1))
-		})
-
 		It("passes a sender that sends messages via the message sink", func() {
 			h1.HandleMessageFunc = func(ctx context.Context, s ax.Sender, _ ax.MessageContext) error {
 				_, err := s.ExecuteCommand(ctx, &testmessages.Command{})

--- a/src/axmysql/outbox/repository.go
+++ b/src/axmysql/outbox/repository.go
@@ -18,7 +18,7 @@ type Repository struct{}
 const messageTable = "ax_outbox_message"
 
 // LoadOutbox loads the unsent outbound messages that were produced when the
-// message identified by id was first delivered.
+// message identified by id was first processed.
 func (Repository) LoadOutbox(
 	ctx context.Context,
 	ds persistence.DataStore,
@@ -70,7 +70,7 @@ func (Repository) LoadOutbox(
 }
 
 // SaveOutbox saves a set of unsent outbound messages that were produced
-// when the message identified by id was delivered.
+// when the message identified by id was processed.
 func (Repository) SaveOutbox(
 	ctx context.Context,
 	ptx persistence.Tx,

--- a/src/axmysql/projection/readmodel.go
+++ b/src/axmysql/projection/readmodel.go
@@ -100,7 +100,7 @@ func (p ReadModelProjector) MessageTypes() ax.MessageTypeSet {
 }
 
 // ApplyMessage invokes application-defined logic that updates the
-// application state to reflect the delivery of a message.
+// application state to reflect the occurrence of a message.
 //
 // It may panic if env.Message is not one of the types described by
 // MessageTypes().

--- a/src/axrmq/acknowledger.go
+++ b/src/axrmq/acknowledger.go
@@ -16,15 +16,15 @@ type Acknowledger struct {
 }
 
 // Ack acknowledges the message, indicating that is was handled successfully
-// and does not need to be redelivered.
+// and does not need to be retried.
 func (a *Acknowledger) Ack(_ context.Context) error {
 	return a.del.Ack(false) // false = single message
 }
 
-// Retry requeues the message so that it is redelivered at some point in the
+// Retry requeues the message so that it is retried at some point in the
 // future.
 //
-// d is a hint as to how long the transport should wait before redelivering
+// d is a hint as to how long the transport should wait before retrying
 // this message.
 func (a *Acknowledger) Retry(ctx context.Context, _ error, d time.Duration) error {
 	if d >= 0 {
@@ -35,7 +35,7 @@ func (a *Acknowledger) Retry(ctx context.Context, _ error, d time.Duration) erro
 
 	// Rejecting the message causes it to be requeued in the *same queue* via
 	// the DLX configuration. This allows us to use the DLX x-death header to
-	// get a redelivery count.
+	// get an attempt count.
 	return a.del.Reject(false) // true = don't requeue
 }
 

--- a/src/axrmq/marshaling.go
+++ b/src/axrmq/marshaling.go
@@ -50,8 +50,8 @@ func marshalMessage(ep string, env endpoint.OutboundEnvelope) (amqp.Publishing, 
 func unmarshalMessage(del amqp.Delivery) (endpoint.InboundEnvelope, error) {
 	env := endpoint.InboundEnvelope{
 		SourceEndpoint: del.AppId,
-		DeliveryID:     endpoint.GenerateDeliveryID(),
-		DeliveryCount:  countDeliveries(del),
+		AttemptID:      endpoint.GenerateAttemptID(),
+		AttemptCount:   countAttempts(del),
 	}
 
 	if err := env.MessageID.Parse(del.MessageId); err != nil {
@@ -85,9 +85,9 @@ func unmarshalMessage(del amqp.Delivery) (endpoint.InboundEnvelope, error) {
 	return env, err
 }
 
-// countDeliveries attempts to return the number of times the given message has
-// been delievered. It returns zero if the count is unknown.
-func countDeliveries(del amqp.Delivery) uint {
+// countAttempts returns the number of times the given message has been
+// delievered. It returns zero if the count is unknown.
+func countAttempts(del amqp.Delivery) uint {
 	death, ok := del.Headers["x-death"]
 
 	if !ok {


### PR DESCRIPTION
- Store the inbound envelope in the context, allowing the logger access to delivery information (fixes #68)
- Rename "deliveries" to "attempts", as it's clearer without explanation
- Log "attempt" information in outbound message logs
