### PR TITLE
Do not obtain a logger from the endpoint.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,7 @@ src/axtest/mocks/persistence.go: $(wildcard src/ax/persistence/*.go) | $(MOQ)
 
 src/axtest/mocks/observability.go: $(wildcard src/ax/observability/*.go) | $(MOQ)
 	$(MOQ) -out "$@" -pkg "mocks" src/ax/observability \
-		InboundObserver \
-		OutboundObserver
+		Observer
 
 artifacts/make/%/Makefile:
 	curl -sf https://jmalloc.github.io/makefiles/fetch | bash /dev/stdin $*

--- a/src/ax/endpoint/endpoint.go
+++ b/src/ax/endpoint/endpoint.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/jmalloc/ax/src/ax"
-	"github.com/jmalloc/twelf/src/twelf"
 )
 
 // Endpoint is a named source and recipient of messages.
@@ -18,7 +17,6 @@ type Endpoint struct {
 	OutboundPipeline  OutboundPipeline
 	RetryPolicy       RetryPolicy
 	SenderValidators  []Validator
-	Logger            twelf.Logger
 
 	initOnce sync.Once
 }

--- a/src/ax/observability/hook.go
+++ b/src/ax/observability/hook.go
@@ -9,7 +9,7 @@ import (
 // InboundHook is an inbound pipeline stage that invokes hook methods
 // on a set of observers.
 type InboundHook struct {
-	Observers []InboundObserver
+	Observers []Observer
 	Next      endpoint.InboundPipeline
 }
 
@@ -17,12 +17,6 @@ type InboundHook struct {
 // transport is initialized. It can be used to inspect or further configure the
 // endpoint as per the needs of the pipeline.
 func (h *InboundHook) Initialize(ctx context.Context, ep *endpoint.Endpoint) error {
-	for _, o := range h.Observers {
-		if err := o.InitializeInbound(ctx, ep); err != nil {
-			return err
-		}
-	}
-
 	return h.Next.Initialize(ctx, ep)
 }
 
@@ -45,7 +39,7 @@ func (h *InboundHook) Accept(ctx context.Context, s endpoint.MessageSink, env en
 // OutboundHook is an outbound pipeline stage that invokes hook methods
 // on a set of observers.
 type OutboundHook struct {
-	Observers []OutboundObserver
+	Observers []Observer
 	Next      endpoint.OutboundPipeline
 }
 
@@ -53,12 +47,6 @@ type OutboundHook struct {
 // transport is initialized. It can be used to inspect or further configure the
 // endpoint as per the needs of the pipeline.
 func (h *OutboundHook) Initialize(ctx context.Context, ep *endpoint.Endpoint) error {
-	for _, o := range h.Observers {
-		if err := o.InitializeOutbound(ctx, ep); err != nil {
-			return err
-		}
-	}
-
 	return h.Next.Initialize(ctx, ep)
 }
 

--- a/src/ax/observability/hook_test.go
+++ b/src/ax/observability/hook_test.go
@@ -15,7 +15,7 @@ import (
 
 var _ = Describe("InboundHook", func() {
 	var (
-		observer *mocks.InboundObserverMock
+		observer *mocks.ObserverMock
 		ep       *endpoint.Endpoint
 		next     *mocks.InboundPipelineMock
 		env      endpoint.InboundEnvelope
@@ -24,10 +24,9 @@ var _ = Describe("InboundHook", func() {
 
 	BeforeEach(func() {
 		ep = &endpoint.Endpoint{}
-		observer = &mocks.InboundObserverMock{
-			InitializeInboundFunc: func(context.Context, *endpoint.Endpoint) error { return nil },
-			BeforeInboundFunc:     func(context.Context, endpoint.InboundEnvelope) {},
-			AfterInboundFunc:      func(context.Context, endpoint.InboundEnvelope, error) {},
+		observer = &mocks.ObserverMock{
+			BeforeInboundFunc: func(context.Context, endpoint.InboundEnvelope) {},
+			AfterInboundFunc:  func(context.Context, endpoint.InboundEnvelope, error) {},
 		}
 		next = &mocks.InboundPipelineMock{
 			InitializeFunc: func(context.Context, *endpoint.Endpoint) error { return nil },
@@ -40,28 +39,11 @@ var _ = Describe("InboundHook", func() {
 		}
 		hook = &InboundHook{
 			Next:      next,
-			Observers: []InboundObserver{observer},
+			Observers: []Observer{observer},
 		}
 	})
 
 	Describe("Initialize", func() {
-		It("initializes the observers", func() {
-			err := hook.Initialize(context.Background(), ep)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(observer.InitializeInboundCalls()).To(HaveLen(1))
-			Expect(observer.InitializeInboundCalls()[0].Ep).To(Equal(ep))
-		})
-
-		It("fails if observer initialization fails", func() {
-			expected := errors.New("<error>")
-			observer.InitializeInboundFunc = func(context.Context, *endpoint.Endpoint) error {
-				return expected
-			}
-
-			err := hook.Initialize(context.Background(), ep)
-			Expect(err).To(Equal(expected))
-		})
-
 		It("initializes the next stage", func() {
 			err := hook.Initialize(context.Background(), ep)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -119,7 +101,7 @@ var _ = Describe("InboundHook", func() {
 
 var _ = Describe("OutboundHook", func() {
 	var (
-		observer *mocks.OutboundObserverMock
+		observer *mocks.ObserverMock
 		ep       *endpoint.Endpoint
 		next     *mocks.OutboundPipelineMock
 		env      endpoint.OutboundEnvelope
@@ -128,10 +110,9 @@ var _ = Describe("OutboundHook", func() {
 
 	BeforeEach(func() {
 		ep = &endpoint.Endpoint{}
-		observer = &mocks.OutboundObserverMock{
-			InitializeOutboundFunc: func(context.Context, *endpoint.Endpoint) error { return nil },
-			BeforeOutboundFunc:     func(context.Context, endpoint.OutboundEnvelope) {},
-			AfterOutboundFunc:      func(context.Context, endpoint.OutboundEnvelope, error) {},
+		observer = &mocks.ObserverMock{
+			BeforeOutboundFunc: func(context.Context, endpoint.OutboundEnvelope) {},
+			AfterOutboundFunc:  func(context.Context, endpoint.OutboundEnvelope, error) {},
 		}
 		next = &mocks.OutboundPipelineMock{
 			InitializeFunc: func(context.Context, *endpoint.Endpoint) error { return nil },
@@ -144,28 +125,11 @@ var _ = Describe("OutboundHook", func() {
 		}
 		hook = &OutboundHook{
 			Next:      next,
-			Observers: []OutboundObserver{observer},
+			Observers: []Observer{observer},
 		}
 	})
 
 	Describe("Initialize", func() {
-		It("initializes the observers", func() {
-			err := hook.Initialize(context.Background(), ep)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(observer.InitializeOutboundCalls()).To(HaveLen(1))
-			Expect(observer.InitializeOutboundCalls()[0].Ep).To(Equal(ep))
-		})
-
-		It("fails if observer initialization fails", func() {
-			expected := errors.New("<error>")
-			observer.InitializeOutboundFunc = func(context.Context, *endpoint.Endpoint) error {
-				return expected
-			}
-
-			err := hook.Initialize(context.Background(), ep)
-			Expect(err).To(Equal(expected))
-		})
-
 		It("initializes the next stage", func() {
 			err := hook.Initialize(context.Background(), ep)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/src/ax/observability/logging.go
+++ b/src/ax/observability/logging.go
@@ -34,19 +34,7 @@ const (
 
 // LoggingObserver is an observer that logs about messages.
 type LoggingObserver struct {
-	logger twelf.Logger
-}
-
-// InitializeInbound initializes the observer for inbound messages.
-func (o *LoggingObserver) InitializeInbound(ctx context.Context, ep *endpoint.Endpoint) error {
-	o.logger = ep.Logger
-	return nil
-}
-
-// InitializeOutbound initializes the observer for outbound messages.
-func (o *LoggingObserver) InitializeOutbound(ctx context.Context, ep *endpoint.Endpoint) error {
-	o.logger = ep.Logger
-	return nil
+	Logger twelf.Logger
 }
 
 // BeforeInbound logs information about an inbound message.
@@ -80,7 +68,7 @@ func (o *LoggingObserver) AfterOutbound(ctx context.Context, env endpoint.Outbou
 
 func (o *LoggingObserver) logMessage(typeIcon, statusIcon string, env ax.Envelope) {
 	twelf.LogString(
-		o.logger,
+		o.Logger,
 		formatLogMessage(
 			typeIcon,
 			statusIcon,
@@ -92,7 +80,7 @@ func (o *LoggingObserver) logMessage(typeIcon, statusIcon string, env ax.Envelop
 
 func (o *LoggingObserver) logError(typeIcon string, env ax.Envelope, err error) {
 	twelf.LogString(
-		o.logger,
+		o.Logger,
 		formatLogMessage(
 			typeIcon,
 			errorIcon,

--- a/src/ax/observability/logging_test.go
+++ b/src/ax/observability/logging_test.go
@@ -14,15 +14,13 @@ import (
 )
 
 var (
-	ensureLoggingObserverIsInboundObserver  InboundObserver  = &LoggingObserver{}
-	ensureLoggingObserverIsOutboundObserver OutboundObserver = &LoggingObserver{}
+	ensureLoggingObserverIsObserver Observer = &LoggingObserver{}
 )
 
-var _ = Describe("Logger", func() {
+var _ = Describe("LoggingObserver", func() {
 	var (
 		logger   = &twelf.BufferedLogger{}
-		observer = &LoggingObserver{}
-		ep       = &endpoint.Endpoint{
+		observer = &LoggingObserver{
 			Logger: logger,
 		}
 	)
@@ -52,12 +50,6 @@ var _ = Describe("Logger", func() {
 	})
 
 	Context("inbound messages", func() {
-		BeforeEach(func() {
-			if err := observer.InitializeInbound(context.Background(), ep); err != nil {
-				panic(err)
-			}
-		})
-
 		Describe("BeforeInbound", func() {
 			It("logs information about the message", func() {
 				ctx := endpoint.WithEnvelope(context.Background(), in)
@@ -97,12 +89,6 @@ var _ = Describe("Logger", func() {
 	})
 
 	Context("outbound messages", func() {
-		BeforeEach(func() {
-			if err := observer.InitializeOutbound(context.Background(), ep); err != nil {
-				panic(err)
-			}
-		})
-
 		Describe("BeforeOutbound", func() {
 			It("logs information about the message", func() {
 				observer.BeforeOutbound(context.Background(), out)

--- a/src/ax/observability/observer.go
+++ b/src/ax/observability/observer.go
@@ -6,23 +6,15 @@ import (
 	"github.com/jmalloc/ax/src/ax/endpoint"
 )
 
-// InboundObserver is an interface for types that observe inbound messages.
-type InboundObserver interface {
-	// InitializeInbound initializes the observer for inbound messages.
-	InitializeInbound(ctx context.Context, ep *endpoint.Endpoint) error
-
+// Observer is an interface for types that observe the messages sent and
+// received by an endpoint.
+type Observer interface {
 	// BeforeInbound is called before a message is passed to the next pipeline stage.
 	BeforeInbound(ctx context.Context, env endpoint.InboundEnvelope)
 
 	// AfterInbound is called after a message is accepted by the next pipeline stage.
 	// err is the error returned by the next pipeline stage, which may be nil.
 	AfterInbound(ctx context.Context, env endpoint.InboundEnvelope, err error)
-}
-
-// OutboundObserver is an interface for types that observe outbound messages.
-type OutboundObserver interface {
-	// InitializeOutbound initializes the observer for outbound messages.
-	InitializeOutbound(ctx context.Context, ep *endpoint.Endpoint) error
 
 	// BeforeOutbound is called before a message is passed to the next pipeline stage.
 	BeforeOutbound(ctx context.Context, env endpoint.OutboundEnvelope)
@@ -31,3 +23,23 @@ type OutboundObserver interface {
 	// err is the error returned by the next pipeline stage, which may be nil.
 	AfterOutbound(ctx context.Context, env endpoint.OutboundEnvelope, err error)
 }
+
+// NullObserver is an observer that does nothing.
+//
+// It can be embedded into observer implementations to avoid having to write
+// empty methods.
+type NullObserver struct{}
+
+// BeforeInbound is called before a message is passed to the next pipeline stage.
+func (NullObserver) BeforeInbound(context.Context, endpoint.InboundEnvelope) {}
+
+// AfterInbound is called after a message is accepted by the next pipeline stage.
+// err is the error returned by the next pipeline stage, which may be nil.
+func (NullObserver) AfterInbound(context.Context, endpoint.InboundEnvelope, error) {}
+
+// BeforeOutbound is called before a message is passed to the next pipeline stage.
+func (NullObserver) BeforeOutbound(context.Context, endpoint.OutboundEnvelope) {}
+
+// AfterOutbound is called after a message is accepted by the next pipeline stage.
+// err is the error returned by the next pipeline stage, which may be nil.
+func (NullObserver) AfterOutbound(context.Context, endpoint.OutboundEnvelope, error) {}

--- a/src/ax/routing/dispatcher.go
+++ b/src/ax/routing/dispatcher.go
@@ -13,9 +13,9 @@ import (
 // appropriate MessageHandler instances according to a "handler table".
 type Dispatcher struct {
 	Routes HandlerTable
+	Logger twelf.Logger
 
 	validators []endpoint.Validator
-	logger     twelf.Logger
 }
 
 // Initialize is called during initialization of the endpoint, after the
@@ -23,7 +23,6 @@ type Dispatcher struct {
 // endpoint as per the needs of the pipeline.
 func (d *Dispatcher) Initialize(ctx context.Context, ep *endpoint.Endpoint) error {
 	d.validators = ep.SenderValidators
-	d.logger = ep.Logger
 
 	var unicast, multicast ax.MessageTypeSet
 
@@ -61,7 +60,7 @@ func (d *Dispatcher) Accept(ctx context.Context, s endpoint.MessageSink, env end
 	mctx := ax.NewMessageContext(
 		env.Envelope,
 		observability.NewDomainLogger(
-			d.logger,
+			d.Logger,
 			env.Envelope,
 		),
 	)


### PR DESCRIPTION
There was a recent change I made that started us down a path of using the endpoint as a poor man's service locator, a pattern I'd like to avoid.

This change removes the logger from the `Endpoint` altogether, instead injecting it directly as a dependency to anything that needs it, as we should always be doing.

As part of this change I've (re)simplified the `observability` package, removing the ability for observers to access the `Endpoint`.

I suspect long-term that `Endpoint` will go away, replaced with some convenience functions that wire everything together based on a set of user-friendly options.