### PR TITLE
Add new indefinite retry policy changing it to default

### DIFF
--- a/endpoint/retry.go
+++ b/endpoint/retry.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"math"
+	"math/rand"
 	"time"
 )
 
@@ -15,15 +16,18 @@ type RetryPolicy func(InboundEnvelope, error) (time.Duration, bool)
 // DefaultRetryPolicy is the default RetryPolicy.
 //
 // It allows for 3 immediate attempts, after which each attempt is delayed
-// exponentially, for a maximum of 10 attempts before the message is rejected.
-var DefaultRetryPolicy = NewExponentialBackoffPolicy(3, 10, 1*time.Second)
+// exponentially until 5-minute maximum delay interval is reached. After that
+// the message is retried indefinitely with the maximum delay interval. Every
+// single delay produced by this policy is randomized within the following
+// range: [ d-(d*02), d+(d*02) ], where d is the calculated delay.
+var DefaultRetryPolicy = NewIndefiniteRetryPolicy(3, 1*time.Second, 5*time.Minute, 0.2)
 
 // NewExponentialBackoffPolicy returns a retry policy that allows a fixed number
 // of immediate attempts after which retries are delayed exponentially for a
 // fixed number of total attempts before the message is rejected.
 //
 // i is the number of immediate attempts. m is the maximum total attempts, and
-// d is a multplier for the backoff duration.
+// d is a multiplier for the backoff duration.
 func NewExponentialBackoffPolicy(i, m uint, d time.Duration) RetryPolicy {
 	return func(env InboundEnvelope, _ error) (time.Duration, bool) {
 		n := env.AttemptCount
@@ -34,7 +38,7 @@ func NewExponentialBackoffPolicy(i, m uint, d time.Duration) RetryPolicy {
 		}
 
 		// If the attempt count is unknown, always retry, but always use the
-		// maximium backoff period.
+		// maximum backoff period.
 		if n == 0 {
 			n = m
 		}
@@ -52,4 +56,71 @@ func NewExponentialBackoffPolicy(i, m uint, d time.Duration) RetryPolicy {
 
 		return time.Duration(p) * d, true
 	}
+}
+
+// NewIndefiniteRetryPolicy is the policy that regulates indefinite amount of
+// retry attempts. Similar to NewExponentialBackoffPolicy, this policy allows a
+// fixed number of immediate attempts and calculates the next delay
+// exponentially. However, contrary to NewExponentialBackoffPolicy, this policy
+// always returns true as the second return value denoting that the message
+// should be retried indefinitely.
+//
+// i is the number of immediate attempts. d is a multiplier for the backoff
+// duration. dmax is the maximum backoff duration. randomize is the
+// randomization factor used to randomize the returned duration within the
+// following range:
+//
+// [ d-(d*randomize), d+(d*randomize) ]
+//
+// If d exceeds dmax, dmax value is used to randomize duration.
+func NewIndefiniteRetryPolicy(i uint, d, dmax time.Duration, randomize float64) RetryPolicy {
+	// lastDelay is the last computed delay returned by this retry policy
+	var lastDelay time.Duration
+	return func(env InboundEnvelope, _ error) (time.Duration, bool) {
+		n := env.AttemptCount
+
+		// Retry immediately if we haven't yet exhausted the immediate attempt
+		// limit.
+		if n < i {
+			return 0, true
+		}
+
+		// If the attempt count is unknown, always retry, but always use the
+		// maximum backoff period.
+		if n == 0 {
+			lastDelay = dmax
+			return randomizeDuration(dmax, randomize), true
+		}
+
+		// lastDelay has already been set to dmax, randomize dmax and return
+		if lastDelay == dmax {
+			return randomizeDuration(dmax, randomize), true
+		}
+
+		// Calculate the next exponential value
+		p := math.Pow(
+			2,
+			float64(n-i), // number of non-immediate attempts
+		)
+
+		if delay := time.Duration(p) * d; delay < dmax {
+			lastDelay = delay
+			return randomizeDuration(delay, randomize), true
+		}
+		// If we ended up here, delay is already exceeding dmax value.
+		// In this case we set lastDelay to dmax to signify that from now on
+		// we will keep returning dmax.
+		lastDelay = dmax
+		return randomizeDuration(dmax, randomize), true
+	}
+}
+
+// randomizeDuration randomizes d based on the randomization factor. The
+// randomized duration is guranteed to be within the range of
+// [ d-(d*randomize), d+(d*randomize) ].
+func randomizeDuration(d time.Duration, randomize float64) time.Duration {
+	f := float64(d)
+	delta := f * randomize
+	min, max := f-delta, f+delta
+	return time.Duration(min + (rand.Float64() * (max - min + 1)))
 }

--- a/endpoint/retry.go
+++ b/endpoint/retry.go
@@ -79,17 +79,17 @@ func NewIndefiniteRetryPolicy(i uint, d, dmax time.Duration, randomize float64) 
 	return func(env InboundEnvelope, _ error) (time.Duration, bool) {
 		n := env.AttemptCount
 
-		// Retry immediately if we haven't yet exhausted the immediate attempt
-		// limit.
-		if n < i {
-			return 0, true
-		}
-
 		// If the attempt count is unknown, always retry, but always use the
 		// maximum backoff period.
 		if n == 0 {
 			lastDelay = dmax
 			return randomizeDuration(dmax, randomize), true
+		}
+
+		// Retry immediately if we haven't yet exhausted the immediate attempt
+		// limit.
+		if n < i {
+			return 0, true
 		}
 
 		// lastDelay has already been set to dmax, randomize dmax and return


### PR DESCRIPTION
This PR introduces a new indefinite retry policy and sets it to be default retry policy in `ax`. 

The policy introduced allows users to specify maximum retry backoff duration and randomization factor that assisting 'jittering' message retries within a specific range. 