### PR TITLE
Truncate msg descr before the DB insert.

### DIFF
--- a/axmysql/messagestore/append.go
+++ b/axmysql/messagestore/append.go
@@ -146,8 +146,12 @@ func insertMessage(
 		return err
 	}
 
-	// Truncate the message to 255 characters to fit within the column.
-	descrTrunc := env.Message.MessageDescription()[:255]
+	descr := env.Message.MessageDescription()
+	// Truncate the message to 255 characters to fit within the column, if
+	// required.
+	if len(env.Message.MessageDescription()) > 255 {
+		descr = descr[:255]
+	}
 
 	_, err = tx.ExecContext(
 		ctx,
@@ -166,7 +170,7 @@ func insertMessage(
 		g,
 		id,
 		o,
-		descrTrunc,
+		descr,
 		env.MessageID,
 		env.CausationID,
 		env.CorrelationID,

--- a/axmysql/messagestore/append.go
+++ b/axmysql/messagestore/append.go
@@ -146,6 +146,12 @@ func insertMessage(
 		return err
 	}
 
+	// Truncate the message to 255 characters to fit in the schema restriction;
+	// see
+	// https://github.com/jmalloc/ax/blob/v0.4.0/axmysql/messagestore/schema.sql#L37
+	// for details.
+	descrTrunc := env.Message.MessageDescription()[:255]
+
 	_, err = tx.ExecContext(
 		ctx,
 		`INSERT INTO ax_messagestore_message SET
@@ -163,7 +169,7 @@ func insertMessage(
 		g,
 		id,
 		o,
-		env.Message.MessageDescription(),
+		descrTrunc,
 		env.MessageID,
 		env.CausationID,
 		env.CorrelationID,

--- a/axmysql/messagestore/append.go
+++ b/axmysql/messagestore/append.go
@@ -149,7 +149,7 @@ func insertMessage(
 	descr := env.Message.MessageDescription()
 	// Truncate the message to 255 characters to fit within the column, if
 	// required.
-	if len(env.Message.MessageDescription()) > 255 {
+	if len(descr) > 255 {
 		descr = descr[:255]
 	}
 

--- a/axmysql/messagestore/append.go
+++ b/axmysql/messagestore/append.go
@@ -146,10 +146,7 @@ func insertMessage(
 		return err
 	}
 
-	// Truncate the message to 255 characters to fit in the schema restriction;
-	// see
-	// https://github.com/jmalloc/ax/blob/v0.4.0/axmysql/messagestore/schema.sql#L37
-	// for details.
+	// Truncate the message to 255 characters to fit within the column.
 	descrTrunc := env.Message.MessageDescription()[:255]
 
 	_, err = tx.ExecContext(

--- a/axmysql/saga/crud.go
+++ b/axmysql/saga/crud.go
@@ -164,6 +164,13 @@ func (CRUDRepository) insertInstance(
 	contentType string,
 	data []byte,
 ) (bool, error) {
+	descr := i.Data.InstanceDescription()
+	// Truncate the message to 255 characters to fit within the column, if
+	// required.
+	if len(descr) > 255 {
+		descr = descr[:255]
+	}
+
 	_, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO ax_saga_instance SET
@@ -175,7 +182,7 @@ func (CRUDRepository) insertInstance(
 			data = ?`,
 		i.InstanceID,
 		pk,
-		i.Data.InstanceDescription(),
+		descr,
 		contentType,
 		data,
 	)

--- a/axmysql/saga/snapshot.go
+++ b/axmysql/saga/snapshot.go
@@ -92,6 +92,13 @@ func (SnapshotRepository) SaveSagaSnapshot(
 		return err
 	}
 
+	descr := i.Data.InstanceDescription()
+	// Truncate the message to 255 characters to fit within the column, if
+	// required.
+	if len(descr) > 255 {
+		descr = descr[:255]
+	}
+
 	_, err = tx.ExecContext(
 		ctx,
 		`INSERT INTO ax_saga_snapshot SET
@@ -104,7 +111,7 @@ func (SnapshotRepository) SaveSagaSnapshot(
 		i.InstanceID,
 		i.Revision,
 		pk,
-		i.Data.InstanceDescription(),
+		descr,
 		contentType,
 		data,
 	)


### PR DESCRIPTION
This PR truncates the ax message description before the insert to `ax_messagestore_message` table. This is required to fit into the size of `ax_messagestore_message.description` field.

