### PR TITLE
Fix the failing JSON marshalling test.

### DIFF
--- a/marshaling/json_test.go
+++ b/marshaling/json_test.go
@@ -22,7 +22,7 @@ var _ = Describe("MarshalJSON", func() {
 		var m testmessages.NonAxMessage
 		err = json.Unmarshal(data, &m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(m).Should(Equal(*message))
+		Expect(proto.Equal(&m, message)).Should(BeTrue())
 	})
 
 	It("includes the protocol information in the content-type", func() {


### PR DESCRIPTION
This PR fixes the failing JSON marshalling test. The  `github.com/golang/protobuf/proto.Equal()` function is used to compare the protobuf messages now to avoid the test failure within CI environment.